### PR TITLE
Bug/landing page fixes und CR job profiles

### DIFF
--- a/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.html
+++ b/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.html
@@ -20,9 +20,11 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title> IT-Techniker </mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/jbZWHG9F8XRDMdtDrQ6hzLZFUz52"
-                    style="cursor: pointer; background-image: url('https://lh3.googleusercontent.com/a-/AOh14Ghlaad4KD3bCh9g0uaW7R-dX08xrjxMIZQasIbR=s96-c'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('IT-Techniker'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('IT-Techniker')[0].photoURL}}" mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -97,13 +99,29 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2> Stefan Hinterhölzl </h2>
-                            <p> DiversIT-Mentor </p>
-                            <button mat-raised-button routerLink="/profile/jbZWHG9F8XRDMdtDrQ6hzLZFUz52"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('IT-Techniker')" class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('IT-Techniker').length === 0" class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>
@@ -115,9 +133,11 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title> UX-Designer </mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/f0fi5AyuXMSlFcmmJTzErrRqFvx1"
-                    style="cursor: pointer; background-image: url('./../../../../assets/Images/job-profiles/Thomas-Deutsch-small.jpg'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('UX-Designer'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('UX-Designer')[0].photoURL}}" mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -209,13 +229,29 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2> Thomas Deutsch </h2>
-                            <p> DiversIT-Mentor </p>
-                            <button mat-raised-button routerLink="/profile/f0fi5AyuXMSlFcmmJTzErrRqFvx1"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('UX-Designer')" class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('UX-Designer').length === 0" class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>
@@ -227,9 +263,11 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title> Software Engineer </mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/0jiOV3Ihtjg2Gwu3NovseuGTnm02"
-                    style="cursor: pointer; background-image: url('https://drive.google.com/uc?id=1vIxKVqzRvdUi9oHrz0lRrAYffidwTdsu'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('Software Engineer'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('Software Engineer')[0].photoURL}}" mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -321,13 +359,30 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2> Gerald Roither </h2>
-                            <p> DiversIT-Mentor </p>
-                            <button mat-raised-button routerLink="/profile/0jiOV3Ihtjg2Gwu3NovseuGTnm02"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('Software Engineer')"
+                                class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('Software Engineer').length === 0" class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>
@@ -339,9 +394,11 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title> Scrum Master </mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/f0fi5AyuXMSlFcmmJTzErrRqFvx1"
-                    style="cursor: pointer; background-image: url('./../../../../assets/Images/job-profiles/Thomas-Deutsch-small.jpg'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('Scrum Master'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('Scrum Master')[0].photoURL}}" mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -433,13 +490,29 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2> Thomas Deutsch </h2>
-                            <p> DiversIT-Mentor </p>
-                            <button mat-raised-button routerLink="/profile/f0fi5AyuXMSlFcmmJTzErrRqFvx1"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('Scrum Master')" class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('Scrum Master').length === 0" class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>
@@ -451,9 +524,11 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title> Product Owner </mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/zLccCJEzSGap7BlhefDT0xTyi9I3"
-                    style="cursor: pointer; background-image: url('https://drive.google.com/uc?id=1Pt0poYI0Wa4VcxJCL7-uyCDVnnTyTscR'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('Product Owner'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('Product Owner')[0].photoURL}}" mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -545,13 +620,29 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2> Diana Diversit </h2>
-                            <p> DiversIT-Mentorin </p>
-                            <button mat-raised-button routerLink="/profile/3DlpfgwpbxQnLuS3fiw9mKroGm42"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('Product Owner')" class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('Product Owner').length === 0" class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>
@@ -563,9 +654,12 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title> Universitätsprofessor für Informatik </mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/0jiOV3Ihtjg2Gwu3NovseuGTnm02"
-                    style="cursor: pointer; background-image: url('https://drive.google.com/uc?id=1vIxKVqzRvdUi9oHrz0lRrAYffidwTdsu'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('Universitätsprofessor für Informatik'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('Universitätsprofessor für Informatik')[0].photoURL}}"
+                    mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -636,13 +730,31 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2> Gerald Roither </h2>
-                            <p> DiversIT-Mentor </p>
-                            <button mat-raised-button routerLink="/profile/0jiOV3Ihtjg2Gwu3NovseuGTnm02"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('Universitätsprofessor für Informatik')"
+                                class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('Universitätsprofessor für Informatik').length === 0"
+                                class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>
@@ -654,9 +766,11 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title> DevOps Engineer </mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/jbZWHG9F8XRDMdtDrQ6hzLZFUz52"
-                    style="cursor: pointer; background-image: url('https://lh3.googleusercontent.com/a-/AOh14Ghlaad4KD3bCh9g0uaW7R-dX08xrjxMIZQasIbR=s96-c'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('DevOps Engineer'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('DevOps Engineer')[0].photoURL}}" mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -727,13 +841,29 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2> Stefan Hinterhölzl </h2>
-                            <p> DiversIT-Mentor </p>
-                            <button mat-raised-button routerLink="/profile/jbZWHG9F8XRDMdtDrQ6hzLZFUz52"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('DevOps Engineer')" class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('DevOps Engineer').length === 0" class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>
@@ -745,9 +875,11 @@
         <mat-card class="job-card-finetuning">
             <mat-card-header>
                 <mat-card-title>IT-Systemadministrator</mat-card-title>
-                <div mat-card-avatar class="header-image" routerLink="/profile/zLccCJEzSGap7BlhefDT0xTyi9I3"
-                    style="cursor: pointer; background-image: url('https://lh3.googleusercontent.com/a-/AOh14GgI4R9eNIz_VwFXbdXWLELsJAw--55cDl-LKKnJ5uI=s288-p-rw-no'); background-size: cover;">
-                </div>
+                <img *ngIf="firstMentorHasImage('IT-Systemadministrator'); else placeholder"
+                    src="{{jobProfilesMentorsMap.get('IT-Systemadministrator')[0].photoURL}}" mat-card-avatar />
+                <ng-template #placeholder>
+                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                </ng-template>
             </mat-card-header>
             <mat-card-content>
                 <mat-tab-group>
@@ -827,13 +959,31 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Mentor*in">
-                        <div class="container">
-                            <h2>Cornelia Eysn</h2>
-                            <p> DiversIT-Mentorin</p>
-                            <button mat-raised-button routerLink="/profile/zLccCJEzSGap7BlhefDT0xTyi9I3"
-                                class="btn btn-primary"> Zum Profil
-                            </button>
+                    <mat-tab label="MentorInnen">
+                        <div class="mentors">
+                            <div *ngFor="let mentor of jobProfilesMentorsMap.get('IT-Systemadministrator')"
+                                class="container">
+                                <!-- Photo -->
+                                <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unkown; else placeholder"
+                                    src="{{mentor.photoURL}}" mat-card-avatar />
+                                <ng-template #placeholder>
+                                    <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
+                                </ng-template>
+                                <h2> {{mentor.firstname}} {{mentor.lastname}} </h2>
+                                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*
+                                </p>
+                                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary">
+                                    Zum
+                                    Profil
+                                </button>
+                            </div>
+
+                            <div *ngIf="jobProfilesMentorsMap.get('IT-Systemadministrator').length === 0"
+                                class="container">
+                                <p>Aktuell sind für dieses Job-Profil leider keine MentorInnen verfügbar.</p>
+                            </div>
                         </div>
                     </mat-tab>
                 </mat-tab-group>

--- a/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.html
+++ b/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.html
@@ -97,7 +97,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2> Stefan Hinterhölzl </h2>
                             <p> DiversIT-Mentor </p>
@@ -209,7 +209,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2> Thomas Deutsch </h2>
                             <p> DiversIT-Mentor </p>
@@ -321,7 +321,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2> Gerald Roither </h2>
                             <p> DiversIT-Mentor </p>
@@ -433,7 +433,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2> Thomas Deutsch </h2>
                             <p> DiversIT-Mentor </p>
@@ -545,7 +545,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2> Diana Diversit </h2>
                             <p> DiversIT-Mentorin </p>
@@ -636,7 +636,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2> Gerald Roither </h2>
                             <p> DiversIT-Mentor </p>
@@ -727,7 +727,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2> Stefan Hinterhölzl </h2>
                             <p> DiversIT-Mentor </p>
@@ -827,7 +827,7 @@
                             </li>
                         </ul>
                     </mat-tab>
-                    <mat-tab label="Ansprechperson">
+                    <mat-tab label="Mentor*in">
                         <div class="container">
                             <h2>Cornelia Eysn</h2>
                             <p> DiversIT-Mentorin</p>

--- a/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.scss
+++ b/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.scss
@@ -33,6 +33,10 @@
     li p {
         margin-left: 0;
     }
+
+    .mentors {
+        display: flex;
+    }
 }
 
 .job-grid-tile {

--- a/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.ts
+++ b/diversIT/src/app/landing-page/landing-page-components/job-profiles/job-profiles.component.ts
@@ -1,5 +1,7 @@
+import { UserService } from './../../../services/user.service';
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
+import { DiversITUser } from 'src/app/models/users.model';
 
 @Component({
   selector: 'app-job-profiles',
@@ -9,15 +11,25 @@ import { FormControl } from '@angular/forms';
 export class JobProfilesComponent implements OnInit {
 
   breakpoint: number;
-  jobProfiles = new FormControl();
+  numberOfMentors = 3;
+  selectedItems: string[] = ['DevOps Engineer', 'Universitätsprofessor für Informatik', 'Product Owner', 'IT-Systemadministrator'];
+  jobProfiles = new FormControl(this.selectedItems);
   jobProfilesList: string[] = ['IT-Systemadministrator', 'IT-Techniker', 'UX-Designer', 'Software Engineer', 'Universitätsprofessor für Informatik', 'Scrum Master', 'DevOps Engineer', 'Product Owner'].sort();
-  selectedItems: string[] = ['DevOps Engineer', 'IT-Systemadministrator', 'Product Owner', 'UX-Designer'];
+  mentors: DiversITUser[];
+  jobProfilesMentorsMap: Map<string, DiversITUser[]>;
 
+  constructor(private userService: UserService) { }
 
-  constructor() { }
-
-  ngOnInit(): void {
+  async ngOnInit(): Promise<void> {
     this.breakpoint = (window.innerWidth <= 1220) ? 1 : 2;
+    this.initializeJobProfilesMentorsMap(this.jobProfilesList);
+
+    await this.userService.getAllMentorsPromise().then(data => {
+      this.mentors = data;
+    });
+
+    this.setJobProfilesMentors(this.jobProfilesList, this.mentors);
+
   }
 
   onResize(event) {
@@ -39,6 +51,31 @@ export class JobProfilesComponent implements OnInit {
     } else {
       this.selectedItems.push(value);
     }
+  }
+
+  initializeJobProfilesMentorsMap(jobProfiles: string[]) {
+    this.jobProfilesMentorsMap = new Map<string, DiversITUser[]>();
+    jobProfiles.forEach(job => {
+      this.jobProfilesMentorsMap.set(job, []);
+    });
+  }
+
+  setJobProfilesMentors(jobProfiles: string[], mentors: DiversITUser[]): void {
+    jobProfiles.forEach(job => {
+      let jobMentors = mentors.filter(m => m.job === job);
+      if (jobMentors.length > 1) {
+        jobMentors = jobMentors.sort(() => .5 - Math.random()).slice(0, this.numberOfMentors);
+      }
+      this.jobProfilesMentorsMap.set(job, jobMentors);
+    });
+  }
+
+  firstMentorHasImage(jobProfile: string): boolean {
+    return this.jobProfilesMentorsMap
+      && this.jobProfilesMentorsMap.get(jobProfile)
+      && this.jobProfilesMentorsMap.get(jobProfile).length > 0
+      && this.jobProfilesMentorsMap.get(jobProfile)[0].photoURL !== ''
+      && this.jobProfilesMentorsMap.get(jobProfile)[0].photoURL !== 'unknown';
   }
 
 }

--- a/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.html
+++ b/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.html
@@ -18,9 +18,9 @@
 
             <!-- Job And Company -->
             <mat-card-subtitle>
-                <p *ngIf="mentor.gender === 'Female'">DiversIT-Mentorin</p>
-                <p *ngIf="mentor.gender === 'Male'">DiversIT-Mentor</p>
-                <p *ngIf="mentor.gender !== 'Female' && mentor.gender !== 'Male'">DiversIT-Mentor*</p>
+                <p *ngIf="mentor.gender === 'Weiblich'">DiversIT-Mentorin</p>
+                <p *ngIf="mentor.gender === 'Männlich'">DiversIT-Mentor</p>
+                <p *ngIf="mentor.gender !== 'Weiblich' && mentor.gender !== 'Männlich'">DiversIT-Mentor*</p>
                 <p *ngIf="mentor.job !== '' && mentor.company !== ''">{{mentor.job}} bei {{mentor.company}}</p>
                 <p *ngIf="mentor.job ==='' || mentor.company === ''">{{mentor.job}}{{mentor.company}}</p>
                 <!-- Education and Background Infos -->
@@ -37,7 +37,8 @@
         <mat-card-actions>
             <div *ngIf="mentor.maxMentees === -1 || mentor.maxMentees > mentor.mentees.length; else fullcapacity">
                 <p>Freie Mentoring-Plätze!</p>
-                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary"> Mentee werden
+                <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary"> Kontakt
+                    aufnehmen
                 </button>
             </div>
             <ng-template #fullcapacity>

--- a/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.html
+++ b/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.html
@@ -6,7 +6,8 @@
     <mat-card *ngFor="let mentor of mentors" class="mentor-card-finetuning">
         <mat-card-header>
             <!-- Photo -->
-            <img *ngIf="mentor.photoURL !== unknown; else placeholder" src="{{mentor.photoURL}}" mat-card-avatar />
+            <img *ngIf="mentor.photoURL !== '' && mentor.photoURL !== unknown; else placeholder"
+                src="{{mentor.photoURL}}" mat-card-avatar />
             <ng-template #placeholder>
                 <img src="./../../../../../assets/Images/User-Placeholder.png" mat-card-avatar />
             </ng-template>

--- a/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.html
+++ b/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.html
@@ -35,7 +35,7 @@
 
         <!-- CTA and Mentoring Capacity Info -->
         <mat-card-actions>
-            <div *ngIf="mentor.maxMentees &lt; mentor.mentees.length; else fullcapacity">
+            <div *ngIf="mentor.maxMentees === -1 || mentor.maxMentees > mentor.mentees.length; else fullcapacity">
                 <p>Freie Mentoring-Plätze!</p>
                 <button mat-raised-button routerLink="/profile/{{mentor.uid}}" class="btn btn-primary"> Mentee werden
                 </button>

--- a/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.scss
+++ b/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.scss
@@ -1,6 +1,7 @@
 .mentor-card-finetuning {
     height: 100%;
     padding: 30px 80px;
+    margin: 10px;
 
     .mat-card-avatar {
         height: 250px;

--- a/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.ts
+++ b/diversIT/src/app/landing-page/landing-page-components/mentor-spotlight/mentor-spotlight.component.ts
@@ -13,10 +13,10 @@ export class MentorSpotlightComponent implements OnInit {
   numberOfMentors = 1;
   mentors: DiversITUser[];
 
-  constructor(private firestore: UserService) { }
+  constructor(private userService: UserService) { }
 
   ngOnInit(): void {
-    this.firestore.getAllMentorsPromise().then(data => {
+    this.userService.getAllMentorsPromise().then(data => {
       this.mentors = data.sort(() => .5 - Math.random()).slice(0, this.numberOfMentors);
     });
   }

--- a/diversIT/src/app/profile-page/right-panel/rating/rating.component.html
+++ b/diversIT/src/app/profile-page/right-panel/rating/rating.component.html
@@ -17,7 +17,6 @@
                     formControlName="text"></textarea>
             </mat-form-field>
             <div mat-dialog-actions align="end">
-                <a mat-raised-button (click)="sendEmail()" hidden>Als Email senden</a>
                 <button mat-raised-button (click)="saveRating()">Absenden</button>
             </div>
         </form>

--- a/diversIT/src/app/profile-page/right-panel/rating/rating.component.ts
+++ b/diversIT/src/app/profile-page/right-panel/rating/rating.component.ts
@@ -1,6 +1,6 @@
 import { DiversITUser } from './../../../models/users.model';
 import { Rating } from './../../../models/rating.model';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { SnackbarComponent } from 'src/app/snackbar/snackbar.component';
 import { serverTimestamp } from 'firebase/firestore';
@@ -15,8 +15,8 @@ export class RatingComponent implements OnInit {
 
   @Input() currentUser: DiversITUser;
   @Input() ownProfile: boolean;
+  @Output() starCount = 5;
   private rating: number;
-  private starCount = 5;
   ratingForm: FormGroup;
   emailAdress = "diversit.plattform@gmail.com";
   displayForm = true;
@@ -34,14 +34,6 @@ export class RatingComponent implements OnInit {
   onRatingChanged(rating) {
     console.log(rating);
     this.rating = rating;
-  }
-
-  sendEmail() {
-    if (this.isFormDataComplete()) {
-      window.open(`mailto:${this.emailAdress}?Subject=${this.rating}-Sterne Bewertung: ${this.ratingForm.get('summary').value.trim()}&body=${this.ratingForm.get('text').value.trim()} (${this.currentUser.uid})`);
-      this.snackbar.openSnackBar("Email abgesendet? Danke für dein Feedback!", "green-snackbar");
-      this.reset();
-    }
   }
 
   saveRating() {


### PR DESCRIPTION
Bug/landing page fixes und CR job profiles

* kleinere bug fixes auf der landing page für gender check, image check, max mentees capacity check
* CR Job profiles: statt einer Ansprechperson (hardcoded) werden jetzt 3 zufällige Mentoren mit diesem Jobtitel aus der DB angezeigt (wenn weniger verfügbar sind weniger, wenn keine verfügbar sind eine Placeholder message). In der Übersicht wird das Foto vom ersten Mentor genommen.
* Das HTML ist wegen dem vielen hardgecodeten content und der Mischung mit DB-Daten schon schwer zu maintainen und fehleranfällig. Falls da nochmal CRs kommen, wäre es vl doch überlegenswert, sie ganz in die DB zu verlagern.